### PR TITLE
Add explicit permissions to C# CI workflow

### DIFF
--- a/.github/workflows/actions_csharp.yml
+++ b/.github/workflows/actions_csharp.yml
@@ -1,4 +1,6 @@
 name: C#
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Fixes the last Dependabot warning