### PR TITLE
Add thread_local userp when using custom allocator

### DIFF
--- a/CPP/Clipper2Lib/include/clipper2/clipper.allocator.h
+++ b/CPP/Clipper2Lib/include/clipper2/clipper.allocator.h
@@ -7,21 +7,23 @@ namespace Clipper2Lib {
 
 #ifdef clipper2_custom_allocator
 
-	extern void* (*clipper2_malloc)(std::size_t n);
-	extern void  (*clipper2_free)(void* p);
+	thread_local extern void *clipper2_allocator_userp;
+	extern void* (*clipper2_malloc)(void *userp, std::size_t n);
+	extern void  (*clipper2_free)(void *userp, void* p);
 
 	template <class T>
 	struct Allocator
 	{
 		using value_type = T;
 
-		Allocator() = default;
+		Allocator() : userp(clipper2_allocator_userp) {}
 
 		template<class U>
 		constexpr Allocator(const Allocator <U>&) noexcept {}
 
-		T* allocate(std::size_t n) { return (T*)clipper2_malloc(n * sizeof(T)); }
-		void deallocate(T* p, std::size_t) { clipper2_free((void*)p); }
+		void *userp = NULL;
+		T* allocate(std::size_t n) { return (T*)clipper2_malloc(userp, n * sizeof(T)); }
+		void deallocate(T* p, std::size_t) { clipper2_free(userp, (void*)p); }
 	};
 
 	template <class T, class U>

--- a/CPP/Clipper2Lib/src/clipper.engine.cpp
+++ b/CPP/Clipper2Lib/src/clipper.engine.cpp
@@ -26,8 +26,9 @@ namespace Clipper2Lib {
   static const Rect64 invalid_rect = Rect64(false);
 
 #ifdef clipper2_custom_allocator
-  void* (*clipper2_malloc)(std::size_t n) = malloc;
-  void  (*clipper2_free)(void* p) = free;
+  thread_local void *clipper2_allocator_userp = NULL;
+  void* (*clipper2_malloc)(void *userp, std::size_t n);
+  void  (*clipper2_free)(void *userp, void* p);
 #endif
 
   // Every closed path (ie polygon) is made up of a series of vertices forming edge 


### PR DESCRIPTION
We need the clipper2 Path's Allocator to track its allocator in a fashion that is compatible with our nestable push/pop allocator strategy.